### PR TITLE
Fix error on self-hosted runner

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -30,7 +30,7 @@ export const run = async (inputs: Inputs): Promise<void> => {
       const extracted = await tc.extractTar(downloaded)
       core.info(`Install from ${extracted}`)
       await io.mkdirP(`${os.homedir()}/.aqua/bin`)
-      await io.mv(`${extracted}/aqua`, `${os.homedir()}/.aqua/bin/aqua`)
+      await io.cp(`${extracted}/aqua`, `${os.homedir()}/.aqua/bin/aqua`)
     })
   }
 


### PR DESCRIPTION
This will fix the following error:

```
Install from /runner/_work/_temp/149da902-0ddd-455c-8d0c-e073f16230e8
Error: Error: EXDEV: cross-device link not permitted, rename '/runner/_work/_temp/149da902-0ddd-455c-8d0c-e073f16230e8/aqua' -> '/home/runner/.aqua/bin/aqua'
```