### PR TITLE
fix: rename some repositories owner

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,7 +1,7 @@
 {
   "extends": [
     "config:base",
-    "github>suzuki-shunsuke/aqua-renovate-config",
+    "github>aquaproj/aqua-renovate-config",
     "github>int128/typescript-action-renovate-config"
   ],
   regexManagers: [

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # aqua-action [![ts](https://github.com/int128/aqua-action/actions/workflows/ts.yaml/badge.svg)](https://github.com/int128/aqua-action/actions/workflows/ts.yaml)
 
-This is an action to install packages using https://github.com/suzuki-shunsuke/aqua.
+This is an action to install packages using https://github.com/aquaproj/aqua.
 
 
 ## Getting Started
@@ -10,7 +10,7 @@ Create `aqua.yaml` and add packages.
 ```yaml
 registries:
 - type: standard
-  ref: v0.10.10 # renovate: depName=suzuki-shunsuke/aqua-registry
+  ref: v0.10.10 # renovate: depName=aquaproj/aqua-registry
 
 packages:
 - name: suzuki-shunsuke/github-comment@v4.0.0 # renovate: depName=suzuki-shunsuke/github-comment

--- a/action.yaml
+++ b/action.yaml
@@ -8,7 +8,7 @@ inputs:
   version:
     description: aqua version
     required: true
-    default: v0.7.16 # renovate: depName=suzuki-shunsuke/aqua
+    default: v0.7.16 # renovate: depName=aquaproj/aqua
   token:
     description: GitHub token
     required: true

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -3,4 +3,4 @@ packages:
 
 registries:
   - type: standard
-    ref: v0.10.10 # renovate: depName=suzuki-shunsuke/aqua-registry
+    ref: v0.10.10 # renovate: depName=aquaproj/aqua-registry

--- a/src/run.ts
+++ b/src/run.ts
@@ -79,7 +79,7 @@ const aquaMetadata = (version: string): Metadata => {
     platform,
     arch,
     version,
-    url: `https://github.com/suzuki-shunsuke/aqua/releases/download/${version}/aqua_${platform}_${arch}.tar.gz`,
+    url: `https://github.com/aquaproj/aqua/releases/download/${version}/aqua_${platform}_${arch}.tar.gz`,
     cacheKey: `aqua-${version}-${platform}-${arch}`,
   }
 }


### PR DESCRIPTION
They were transferred from https://github.com/suzuki-shunsuke to https://github.com/aquaproj

https://docs.github.com/en/repositories/creating-and-managing-repositories/transferring-a-repository

## Check

```console
$ git grep suzuki-shunsuke
.github/workflows/ts.yaml:      # https://github.com/suzuki-shunsuke/github-comment
README.md:- name: suzuki-shunsuke/github-comment@v4.0.0 # renovate: depName=suzuki-shunsuke/github-comment
aqua.yaml:  - name: suzuki-shunsuke/github-comment@v4.0.1
```